### PR TITLE
Updates

### DIFF
--- a/m3u_test.go
+++ b/m3u_test.go
@@ -47,3 +47,10 @@ func TestPlaylistFileNotFound(t *testing.T) {
 		t.Fatalf("Expected parse error")
 	}
 }
+
+func TestPlaylistMissingInf(t *testing.T) {
+	_, err := Parse("testdata/playlist_missing_inf.m3u")
+	if err == nil {
+		t.Fatalf("Expected parse error")
+	}
+}

--- a/testdata/playlist_missing_inf.m3u
+++ b/testdata/playlist_missing_inf.m3u
@@ -1,0 +1,2 @@
+#EXTM3U
+Track1.mp4


### PR DESCRIPTION
Hi, recently I tried using this library and got a crash in my code. I thought it would be better if it returned an error instead of crashing on the file I was using, which did have an error. The crash came from trying to write to the index of -1 of a slice when setting a URI. To fix this, I added a condition that checks if the array has a length of zero first as well as a test to make sure this works.

I also made a few changes that are less important. One is adding a close statement to the reader that is opened and another is returning an error on a malformed time. I know it defaults to 0 on an error and this might have been the desired behavior but I thought it would be better to fail in this case rather than use that. Another is using a boolean value instead of the line count which I believe is more readable.

Finally, another important change was handling blank lines. In the Wikipedia article on M3U, there are several examples of files with blank line that it indicates would have different behavior from what it does now. For example
```
#EXTM3U

#EXTINF:123, Sample artist - Sample title
Sample.mp3

#EXTINF:321,Example Artist - Example title
Greatest Hits\Example.ogg
```
This would previously crash because of the blank line after the header which would trigger the index of out range panic. In addition to that, the blank lines after each file would mean that the URIs are set to be blank, not the intended destinations. To fix this, I added to the conditional that checks for a comment so that it skips the line if it is blank as well and does not attempt to set the URI in the case of a blank line.

I hope you'll consider some of these changes.