### PR TITLE
Include support to allow remote playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 A basic golang [M3U playlist](https://en.wikipedia.org/wiki/M3U) parser library.
 
-## Usage
+## Installation
 ```
 go get github.com/jamesnetherton/m3u
 ```
 
+## Usage
+Example using a local playlist:
 ```go
 package main
 
@@ -16,14 +18,52 @@ import (
 )
 
 func main() {
-	playlist, err := m3u.Parse("playlist.m3u")
+	playlist, err := m3u.Parse("testdata/playlist.m3u")
 
 	if err == nil {
 		for _, track := range playlist.Tracks {
-			fmt.Println("Track name = ", track.Name)
-			fmt.Println("Track length = ", track.Length)
-			fmt.Println("Track URI = ", track.URI)
-		}
+			fmt.Println("Track name:", track.Name)
+			fmt.Println("Track length:", track.Length)
+			fmt.Println("Track URI:", track.URI)
+			fmt.Println("Track Tags:")
+			for i := range track.Tags {
+				fmt.Println(" -",track.Tags[i].Name,"=>",track.Tags[i].Value)
+
+			}
+			fmt.Println("----------")
+		}	
+	} else {
+		fmt.Println(err)
+	}
+}
+```
+
+Example using a remote playlist:
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/jamesnetherton/m3u"
+)
+
+func main() {
+	playlist, err := m3u.Parse("https://raw.githubusercontent.com/jamesnetherton/m3u/master/testdata/playlist.m3u")
+
+	if err == nil {
+		for _, track := range playlist.Tracks {
+			fmt.Println("Track name:", track.Name)
+			fmt.Println("Track length:", track.Length)
+			fmt.Println("Track URI:", track.URI)
+			fmt.Println("Track Tags:")
+			for i := range track.Tags {
+				fmt.Println(" -",track.Tags[i].Name,"=>",track.Tags[i].Value)
+
+			}
+			fmt.Println("----------")
+		}	
+	} else {
+		fmt.Println(err)
 	}
 }
 ```

--- a/m3u.go
+++ b/m3u.go
@@ -3,7 +3,9 @@ package m3u
 import (
 	"bufio"
 	"errors"
-	"github.com/utahta/go-openuri"
+	"io"
+	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -30,7 +32,15 @@ type Track struct {
 
 // Parse parses an m3u playlist with the given file name and returns a Playlist
 func Parse(fileName string) (playlist Playlist, err error) {
-	f, err := openuri.Open(fileName)
+	var f io.ReadCloser
+	var data *http.Response
+	if strings.HasPrefix(fileName, "http://") || strings.HasPrefix(fileName, "https://") {
+		data, err = http.Get(fileName)
+		f = data.Body
+	} else {
+		f, err = os.Open(fileName)
+	}
+	
 	if err != nil {
 		err = errors.New("Unable to open playlist file")
 		return

--- a/m3u.go
+++ b/m3u.go
@@ -3,7 +3,7 @@ package m3u
 import (
 	"bufio"
 	"errors"
-	"os"
+	"github.com/utahta/go-openuri"
 	"regexp"
 	"strconv"
 	"strings"
@@ -30,7 +30,7 @@ type Track struct {
 
 // Parse parses an m3u playlist with the given file name and returns a Playlist
 func Parse(fileName string) (playlist Playlist, err error) {
-	f, err := os.Open(fileName)
+	f, err := openuri.Open(fileName)
 	if err != nil {
 		err = errors.New("Unable to open playlist file")
 		return

--- a/m3u_test.go
+++ b/m3u_test.go
@@ -35,6 +35,36 @@ func TestPlaylist(t *testing.T) {
 	}
 }
 
+func TestRemotePlaylist(t *testing.T) {
+	playlist, _ := Parse("https://raw.githubusercontent.com/jamesnetherton/m3u/master/testdata/playlist.m3u")
+
+	if len(playlist.Tracks) != 5 {
+		t.Fatalf("Expected track count to be 5")
+	}
+
+	for i := 0; i < 5; i++ {
+		if playlist.Tracks[i].Length != i+1 {
+			t.Fatalf("Expected track Length to be %d but was %d", i+1, playlist.Tracks[i].Length)
+		}
+
+		if playlist.Tracks[i].Name != fmt.Sprintf("Track %d", i+1) {
+			t.Fatalf("Expected track name to be Track %d but was '%s'", i+1, playlist.Tracks[i].Name)
+		}
+
+		if playlist.Tracks[i].URI != fmt.Sprintf("Track%d.mp4", i+1) {
+			t.Fatalf("Expected track URI to be Track%d.mp4 but was '%s'", i+1, playlist.Tracks[i].URI)
+		}
+
+                if playlist.Tracks[i].Tags[0].Name != "group-title" {
+			t.Fatalf("Expected tag to be group-title but was '%s'", playlist.Tracks[i].Tags[0].Name)
+                }
+
+                if playlist.Tracks[i].Tags[0].Value != "Album1" {
+			t.Fatalf("Expected group-title tag value to be Album1 but was '%s'", playlist.Tracks[i].Tags[0].Value)
+                }
+	}
+}
+
 func TestPlaylistInvalidHeader(t *testing.T) {
 	_, err := Parse("testdata/playlist_no_header.m3u")
 	if err == nil {


### PR DESCRIPTION
This change allows to parse remote playlists with known protocols like http:// and https:// thanks to @utahta module https://github.com/utahta/go-openuri.

I've added an example in the README.md and a unit test to parse the same playlist using raw data from GitHub.

I hope you like it enough to merge it 👍  