### PR TITLE
chore: modernise CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -14,11 +14,11 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.13.x
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
     - name: Test
       run: go test -v


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v1 to v4
- Update `actions/setup-go` from v1 to v5, switch Go version to `stable` (always tracks latest)
- Move checkout step before setup-go (conventional order)
- Add Dependabot config for weekly GitHub Actions updates

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)